### PR TITLE
time labels in plot are now time strings, max_disp_num is restricted …

### DIFF
--- a/database_test.py
+++ b/database_test.py
@@ -124,6 +124,18 @@ def return_data():
     con.close()
 
 
+def get_party_start():
+    """
+    Returns the party start time.
+    """
+    con = sql.connect("database.db")
+    cur = con.cursor()
+    cur.execute("SELECT * FROM party_global_data")
+    data = cur.fetchall()
+    return data[0][0]
+    con.close()
+
+
 def update_password(username, password):
     """
     This function updates a username with a new password and sets them in the database

--- a/find_max_BACs.py
+++ b/find_max_BACs.py
@@ -1,40 +1,50 @@
 from BAC import *
 from database_test import *
+from datetime import datetime as dt
 
 
 def find_max_BACs(current_time, party_start, max_disp_num):
-    people = []
-    people_to_disp = []
-    final_bacs = []
-    bac_series = []
-    values = []
-    labels = []
-    data = return_data()
-    first_run = True
-    for user in data:
-        person = user[2]
+    people = []  # empty list to contain all users' usernames
+    people_to_disp = []  # empty list to contain usernames of n people with highest bacs, n = max_disp_num
+    final_bacs = []  # empty list to store final bacs of each user in order to sort and select out highest bacs
+    bac_series = []  # empty list to store all bac series, once final_bacs is sorted these series will be selected out and appended to values
+    values = []  # empty list to contain final list of values of bacs for highest users
+    labels = []  # empty list to contain time strings of time series for plotting
+    data = return_data()  # returns all account_holder data as a list of tuples
+    if max_disp_num > len(data):  # make sure max_disp_num cannot exceed number of people (records) in database
+        max_disp_num = len(data)
+    first_run = True  # this is used to only pull the time series once since it is the same for all users
+    for user in data:  # iterate through each user's information tuple
+        person = user[2]  # username is 3rd entry in tuple
         people.append(person)
-        barcode = user[6]
-        drink_times = get_drink_timestamp(barcode)
-        drink_times = [x for x in drink_times if x is not None]
-        height = user[7]
-        weight = user[8]
-        gender = user[10][0]
-        res = BAC(height, weight, gender, drink_times, current_time, party_start)
-        if first_run:
-            labels = res[0]
+        barcode = user[6]  # barcode is 7th entry in tuple
+        drink_times = get_drink_timestamp(barcode)  # uses database_test function to return list of times in seconds from epoch at which user took a drink
+        drink_times = [x for x in drink_times if x is not None]  # removes null values from list, some users may have taken more drinks than others
+        height = user[7]  # height is 8th entry in tuple
+        weight = user[8]  # weight is 9th entry in tuple
+        gender = user[10][0]  # gender is 11th entry in tuple, only the first letter is needed to determine gender in BAC.py
+        res = BAC(height, weight, gender, drink_times, current_time, party_start)  # runs BAC.py func, returns list of two lists [time series, bac series]
+        if first_run:  # just sets the time series the first time this for loop runs, this time series is then converted to time strings
+            minute_labels = res[0]
             first_run = False
         bac_series.append(res[1])
-        final_bacs.append(res[1][-1])
+        final_bacs.append(res[1][-1])  # appends final value of bac_series for each user, this will create a list of current bacs for each user
+    # final_bacs_sorted creates list of tuples containing value and index sorted by final_bacs
     final_bacs_sorted = sorted([(value, index) for index, value in enumerate(final_bacs)], reverse=True)
-    for i in range(max_disp_num):
-        index = final_bacs_sorted[i][1]
+    for i in range(max_disp_num):  # appends people and bac_series to people_to_disp and values respectively for number (max_disp_num) of users with high bacs
+        index = final_bacs_sorted[i][1]  # finds index of highest values (second number in tuple is index)
         people_to_disp.append(people[index])
         this_bac_series = bac_series[index]
+        # appends each value as opposed to appending list, this is due to JS workaround because we weren't able to convert python list of lists into a list of
+        # lists in JS using jinja
         for val in this_bac_series:
             values.append(val)
-    lines = max_disp_num
-    elements = len(values)
-    colors = ["rgba(169,68,66,1)", "rgba(60,118,61,1)", "rgba(49,112,143,1)"]
-    colors = colors[0:lines]
+    lines = max_disp_num  # lines is number of series to plot
+    elements = len(values)  # elements is number of data points in series, needed for plotting in JS
+    colors = ["rgba(169,68,66,1)", "rgba(60,118,61,1)", "rgba(49,112,143,1)", "rgba(230,138,0,1)", "rgba(153,0,153,1)"]  # colors are for different line colors
+    colors = colors[0:lines]  # selects number of colors equal to lines on plot
+    for time in minute_labels:  # converting minute float labels to time strings
+        seconds = time*60 + party_start
+        dt_obj = dt.fromtimestamp(seconds)
+        labels.append(dt_obj.strftime("%I:%M%p"))
     return [values, labels, lines, elements, people_to_disp, colors]

--- a/ptycap.py
+++ b/ptycap.py
@@ -5,6 +5,8 @@ Party captain dashboard
 import os
 from flask import Flask, render_template, request
 from find_max_BACs import *
+from database_test import *
+import time
 
 app = Flask('flaskapp')
 
@@ -26,11 +28,11 @@ def LinePlot():
 
 @app.route("/multi")
 def MultiLinePlot():
-    party_start = 1493008634.6537
-    current_time = 1493026634.7893
-    max_disp_num = 2  # maximum number of users to display on graph
-    if max_disp_num > 3:  # temporary hack because there are only 3 colors in the colors list
-        max_disp_num = 3
+    party_start = get_party_start()
+    current_time = 1493026634.7893  # change to time.time() when actuallly running
+    max_disp_num = 5  # maximum number of users to display on graph, need to pull this from admin settings
+    if max_disp_num > 5:  # more than 5 lines looks too cluttered
+        max_disp_num = 5
     res = find_max_BACs(current_time, party_start, max_disp_num)
     values, labels, lines, elements, people_to_disp, colors = res
     return render_template('MultiLinePlot2.html', values=values, labels=labels, lines=lines, elements=elements, people=people_to_disp, colors=colors)


### PR DESCRIPTION
…to no greater than 5 and no greater than number of users, because of this no need to generate random colors (just hard coded 5 colors), stored party_start in DB and pull from there for algorithm (current_time is hard coded but just needs to be changed to time.time() for demo, added commenting to find_max_BACs.py, need to comment ptycap.py, multilineplot2.html, and BAC.py still, also need to now work on inventory and profit algorithms